### PR TITLE
Use DH_set0_pqg() for OpenSSL 1.1 compatibility

### DIFF
--- a/network.c
+++ b/network.c
@@ -1282,13 +1282,21 @@ DH *
 network_crypto_dh()
 {
 	DH *dhp;
+	BIGNUM *p, *g;
 
 	if ((dhp = DH_new()) == NULL)
 		errx(1, "network_crypto_pubkey: DH_new() failure");
-	if ((dhp->p = BN_bin2bn(mse_P, CRYPTO_INT_LEN, NULL)) == NULL)
+	if ((p = BN_bin2bn(mse_P, CRYPTO_INT_LEN, NULL)) == NULL)
 		errx(1, "network_crypto_pubkey: BN_bin2bn(P) failure");
-	if ((dhp->g = BN_bin2bn(mse_G, CRYPTO_INT_LEN, NULL)) == NULL)
+	if ((g = BN_bin2bn(mse_G, CRYPTO_INT_LEN, NULL)) == NULL)
 		errx(1, "network_crypto_pubkey: BN_bin2bn(G) failure");
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10100000)
+	if (DH_set0_pqg(dhp, p, NULL, g) != 1)
+		errx(1, "DH_set0_pgq failed");
+#else
+	dhp->p = p;
+	dhp->g = g;
+#endif
 	if (DH_generate_key(dhp) == 0)
 		errx(1, "network_crypto_pubkey: DH_generate_key() failure");
 


### PR DESCRIPTION
As per https://www.openssl.org/docs/manmaster/crypto/DH_get0_pqg.html,
the DH_set0_pqg function was added in OpenSSL 1.1.0 (which also mandates
its use), so the conditional compilation is necessary.

Verified unworkable still works by successfully downloading
http://cdimage.debian.org/debian-cd/current-live/amd64/bt-hybrid/debian-live-8.5.0-amd64-standard.iso.torrent

Verified unworkable compiles with both OpenSSL 1.0.2 and OpenSSL
1.1.0-pre5.

fixes #1
